### PR TITLE
Hide graphic blocks from navigation and from search results.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Hide graphic blocks from navigation and from search results. [jone]
 
 
 3.0.0 (2019-11-05)

--- a/ftwbook/graphicblock/profiles/default/propertiestool.xml
+++ b/ftwbook/graphicblock/profiles/default/propertiestool.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+  <object name="navtree_properties" meta_type="Plone Property Sheet">
+
+    <property name="metaTypesNotToList" type="lines" purge="False">
+      <element value="ftwbook.graphicblock.GraphicBlock" />
+    </property>
+
+  </object>
+
+  <object name="site_properties" meta_type="Plone Property Sheet">
+
+    <property name="types_not_searched" type="lines" purge="False">
+      <element value="ftwbook.graphicblock.GraphicBlock" />
+    </property>
+
+  </object>
+
+</object>

--- a/ftwbook/graphicblock/profiles/uninstall/propertiestool.xml
+++ b/ftwbook/graphicblock/profiles/uninstall/propertiestool.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<object name="portal_properties">
+
+  <object name="navtree_properties">
+
+    <property name="metaTypesNotToList" purge="False">
+      <element value="ftwbook.graphicblock.GraphicBlock" remove="True" />
+    </property>
+
+  </object>
+
+  <object name="site_properties">
+
+    <property name="types_not_searched" purge="False">
+      <element value="ftwbook.graphicblock.GraphicBlock" remove="True" />
+    </property>
+
+  </object>
+
+</object>

--- a/ftwbook/graphicblock/upgrades/20191106135343_hide_graphic_blocks_from_navigation_and_from_search_results/propertiestool.xml
+++ b/ftwbook/graphicblock/upgrades/20191106135343_hide_graphic_blocks_from_navigation_and_from_search_results/propertiestool.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+  <object name="navtree_properties" meta_type="Plone Property Sheet">
+
+    <property name="metaTypesNotToList" type="lines" purge="False">
+      <element value="ftwbook.graphicblock.GraphicBlock" />
+    </property>
+
+  </object>
+
+  <object name="site_properties" meta_type="Plone Property Sheet">
+
+    <property name="types_not_searched" type="lines" purge="False">
+      <element value="ftwbook.graphicblock.GraphicBlock" />
+    </property>
+
+  </object>
+
+</object>

--- a/ftwbook/graphicblock/upgrades/20191106135343_hide_graphic_blocks_from_navigation_and_from_search_results/upgrade.py
+++ b/ftwbook/graphicblock/upgrades/20191106135343_hide_graphic_blocks_from_navigation_and_from_search_results/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class HideGraphicBlocksFromNavigationAndFromSearchResults(UpgradeStep):
+    """Hide graphic blocks from navigation and from search results.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Blocks usually should not appear in navigation and search.