### PR TITLE
Downpin ftw.testing (major change and conflict).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ tests_require = [
     'zope.testing',
     'plone.app.testing',
     'plone.mocktestcase',
-    'ftw.testing',
+    'ftw.testing<2a',
     'ftw.testbrowser',
     'ftw.builder',
     'ftw.book [tests]',


### PR DESCRIPTION
There were major changes done in ftw.testing. That was the reason
ftw.testing is pinned down in ftw.book. Because of that there was
a version conflict because ftwbook.graphicblock comes first in
this package and picked the most recent one already."